### PR TITLE
Bugfix: Fix typo the preFilter() function

### DIFF
--- a/R/import_data.R
+++ b/R/import_data.R
@@ -5902,7 +5902,7 @@ preFilter <- function(
       okBiotypes <- unique(switchAnalyzeRlist$isoformFeatures$gene_biotype)
       
       if( !all(acceptedGeneBiotype %in% okBiotypes) ) {
-        notAnnot <- setdff(acceptedGeneBiotype, okBiotypes)
+        notAnnot <- setdiff(acceptedGeneBiotype, okBiotypes)
         
         warning(
           paste(


### PR DESCRIPTION
In the preFilter() function, setting acceptedBiotype caused an error, because it attempted to use the function setdff() instead of setdiff(). Fixed the typo.