### PR TITLE
Feat type casting

### DIFF
--- a/R/import_data.R
+++ b/R/import_data.R
@@ -2940,6 +2940,7 @@ importRdata <- function(
   fixStringTieMinOverlapFrac = 0.2,
   fixStringTieMinOverlapLog2RatioToContender = 0.65,
   estimateDifferentialGeneRange = TRUE,
+  autoCastDesignCol = TRUE,  
   showProgress = TRUE,
   quiet = FALSE
 ) {
@@ -4792,12 +4793,27 @@ importRdata <- function(
         localFormula <- '~ 0 + condition'
         
         
-        ### Check co-founders for group vs continous variables and add to fomula
+        ### Check co-founders for group vs continuous variables and add to formula
         if( ncol(localDesign) > 2 ) {
           for(i in 3:ncol(localDesign) ) { # i <- 4
-            if( class(localDesign[,i]) %in% c('numeric', 'integer') ) {
-              if( uniqueLength( localDesign[,i] ) * 2 <= length(localDesign[,i]) ) {
+            if( is.numeric(localDesign[,i]) ) { #class(localDesign[,i]) %in% c('numeric', 'integer') ) {
+              n_unique <- uniqueLength( localDesign[,i] )
+              n_samples <- length(localDesign[,i])
+              
+              is_ambiguous <- (n_unique < 15) && n_unique * 2 <= n_samples
+              
+              if (is_ambiguous) {
+                warning(
+                  sprintf("Design matrix column '%s' is numeric with %d unique values and may be ambiguous ", colnames(localDesign)[i], n_unique),
+                  "(categorical vs continuous)."
+                  )
+              }
+              if( is_ambiguous && autoCastDesignCol) {
                 localDesign[,i] <- factor(localDesign[,i])
+                warning(
+                  sprintf("Design matrix column '%s' has been automatically cast as a categorical variable.\n ", colnames(localDesign)[i]),
+                  "Set autoCastDesignCol to FALSE in order to leave it as a continuous variable."
+                )
               }
             } else {
               localDesign[,i] <- factor(localDesign[,i])
@@ -5004,9 +5020,24 @@ importRdata <- function(
         ### Check co-founders for group vs continous variables
         if( ncol(localDesign) > 2 ) {
           for(i in 3:ncol(localDesign) ) { # i <- 4
-            if( class(localDesign[,i]) %in% c('numeric', 'integer') ) {
-              if( uniqueLength( localDesign[,i] ) * 2 <= length(localDesign[,i]) ) {
+            if( is.numeric(localDesign[,i]) ) { #class(localDesign[,i]) %in% c('numeric', 'integer') ) {
+              n_unique <- uniqueLength( localDesign[,i] )
+              n_samples <- length(localDesign[,i])
+              
+              is_ambiguous <- (n_unique < 15) && n_unique * 2 <= n_samples
+              
+              if (is_ambiguous) {
+                warning(
+                  sprintf("Design matrix column '%s' is numeric with %d unique values and may be ambiguous ", colnames(localDesign)[i], n_unique),
+                  "(categorical vs continuous)."
+                )
+              }
+              if( is_ambiguous && autoCastDesignCol) {
                 localDesign[,i] <- factor(localDesign[,i])
+                warning(
+                  sprintf("Design matrix column '%s' has been automatically cast as a categorical variable.\n ", colnames(localDesign)[i]),
+                  "Set autoCastDesignCol to FALSE in order to leave it as a continuous variable."
+                )
               }
             } else {
               localDesign[,i] <- factor(localDesign[,i])

--- a/R/import_data.R
+++ b/R/import_data.R
@@ -1891,7 +1891,7 @@ importGTF <- function(
                 overlappingAnnotStart$finalJunctionPos <-
                     myExons2$finalJunctionPos[matchIndex]
 
-                ### Annoate with transcript coordinats
+                ### Annotate with transcript coordinates
                 overlappingAnnotStartPlus <-
                     overlappingAnnotStart[which(
                         overlappingAnnotStart$strand == '+'), ]
@@ -4800,20 +4800,22 @@ importRdata <- function(
               n_unique <- uniqueLength( localDesign[,i] )
               n_samples <- length(localDesign[,i])
               
-              is_ambiguous <- (n_unique < 15) && n_unique * 2 <= n_samples
+              is_ambiguous <- n_unique * 2 <= n_samples
               
               if (is_ambiguous) {
                 warning(
                   sprintf("Design matrix column '%s' is numeric with %d unique values and may be ambiguous ", colnames(localDesign)[i], n_unique),
-                  "(categorical vs continuous)."
+                  "(categorical vs continuous).\n",
+                  "We recommend using integers only for numeric variables, and strings/factors for groups."
                   )
-              }
-              if( is_ambiguous && autoCastDesignCol) {
-                localDesign[,i] <- factor(localDesign[,i])
-                warning(
-                  sprintf("Design matrix column '%s' has been automatically cast as a categorical variable.\n ", colnames(localDesign)[i]),
-                  "Set autoCastDesignCol to FALSE in order to leave it as a continuous variable."
-                )
+              
+                if( (n_unique < 5) && autoCastDesignCol) {
+                  localDesign[,i] <- factor(localDesign[,i])
+                  warning(
+                    sprintf("Design matrix column '%s' has been automatically cast as a categorical variable.\n ", colnames(localDesign)[i]),
+                    "Set autoCastDesignCol to FALSE in order to disable this function and treat is as a continuous variable."
+                  )
+                }
               }
             } else {
               localDesign[,i] <- factor(localDesign[,i])
@@ -5024,20 +5026,22 @@ importRdata <- function(
               n_unique <- uniqueLength( localDesign[,i] )
               n_samples <- length(localDesign[,i])
               
-              is_ambiguous <- (n_unique < 15) && n_unique * 2 <= n_samples
+              is_ambiguous <- n_unique * 2 <= n_samples
               
               if (is_ambiguous) {
                 warning(
                   sprintf("Design matrix column '%s' is numeric with %d unique values and may be ambiguous ", colnames(localDesign)[i], n_unique),
-                  "(categorical vs continuous)."
+                  "(categorical vs continuous).\n",
+                  "We recommend using integers only for numeric variables, and strings/factors for groups."
                 )
-              }
-              if( is_ambiguous && autoCastDesignCol) {
-                localDesign[,i] <- factor(localDesign[,i])
-                warning(
-                  sprintf("Design matrix column '%s' has been automatically cast as a categorical variable.\n ", colnames(localDesign)[i]),
-                  "Set autoCastDesignCol to FALSE in order to leave it as a continuous variable."
-                )
+                
+                if( (n_unique < 5) && autoCastDesignCol) {
+                  localDesign[,i] <- factor(localDesign[,i])
+                  warning(
+                    sprintf("Design matrix column '%s' has been automatically cast as a categorical variable.\n ", colnames(localDesign)[i]),
+                    "Set autoCastDesignCol to FALSE in order to disable this function and treat is as a continuous variable."
+                  )
+                }
               }
             } else {
               localDesign[,i] <- factor(localDesign[,i])

--- a/man/importRdata.Rd
+++ b/man/importRdata.Rd
@@ -56,6 +56,7 @@ importRdata(
     fixStringTieMinOverlapFrac = 0.2,
     fixStringTieMinOverlapLog2RatioToContender = 0.65,
     estimateDifferentialGeneRange = TRUE,
+    autoCastDesignCol = TRUE,
     showProgress = TRUE,
     quiet = FALSE
 )
@@ -147,6 +148,10 @@ A log2 ratio which describes how much larger the overlap between a novel isoform
 
 \item{estimateDifferentialGeneRange}{
 A logic indicating whether to make a very quick estimate of the number of genes with differential isoform usage. Please note this number should be taken as a pilot and cannot be trusted. It merely servers to indcate what could be expected if the data is analyzed with the rest of the IsoformSwitchAnalyzeR. See details for more information. Default is TRUE.
+}
+
+\item{autoCastDesignCol}{
+A logic indicating whether numeric design matrix columns that may represent categorical variables (e.g. few unique values relative to sample size) should be automatically cast to factors. Default is TRUE.
 }
 
 \item{showProgress}{

--- a/vignettes/IsoformSwitchAnalyzeR.Rmd
+++ b/vignettes/IsoformSwitchAnalyzeR.Rmd
@@ -2532,7 +2532,7 @@ myDesign$batch <- factor(c('a','a','b','a','b','b'))
 myDesign
 ```
 
-Please note that confounding effects can both be categorical (e.g. sex) (indicated by type character or factor) and continuous variables (e.g. age) (indicated by numeric or integers) - both will be taken into account. Due to the different interpretation it is recommended to use strings/factors for categorical variables (aka do not use 1 and 2 to indicate batch in the example above (instead use "a" and "b")). The conditions analyzed (as indicated by the "condition" column in the design matrix) must however always be categorical (character or factor).
+Please note that confounding effects can both be categorical (e.g. sex) (indicated by type character or factor) and continuous variables (e.g. age) (indicated by numeric or integers) - both will be taken into account. Due to the different interpretation it is recommended to use strings/factors for categorical variables (aka do not use 1 and 2 to indicate batch in the example above (instead use "a" and "b")). Numeric variables with few unique values may be ambiguous between categorical and continuous and may therefore be automatically cast to factors; this behavior can be controlled via the autoCastDesignCol argument to importRdata(). The conditions analyzed (as indicated by the "condition" column in the design matrix) must however always be categorical (character or factor).
 
 Back to [Table of Content]
 


### PR DESCRIPTION
This PR fixes the bug reported in issue #296  by making the automatic casting of numeric design matrix columns explicit and optional. A new argument, autoCastDesignCol, was added to importRdata() to control whether numeric variables that may represent categorical groups are automatically converted to factors (default TRUE). Ambiguous numeric columns now trigger a warning, improving transparency and preventing unintended rank-deficient design matrices when analyzing subsets of samples. The conditions to trigger auto type casting have also been changed to make them less strict on bigger datasets.
Changes are reflected in the man page for this function and on the vignette.