### PR TITLE
Fix boundary overlap when splitting fasta sequences in extractSquence

### DIFF
--- a/R/analyze_ORF.R
+++ b/R/analyze_ORF.R
@@ -1209,15 +1209,11 @@ extractSequence <- function(
                 nFiles <- ceiling(l / maxfileSizes)
                 seqWithinEachFile <-  ceiling(l / nFiles)
 
-                indexVec <- unique( c( seq(
-                    from = 1,
-                    to = l,
-                    by = seqWithinEachFile # Max in PFAM Jan 2019
-                ), l))
+                starts <- seq(from = 1, to = l, by = seqWithinEachFile)
 
                 indexDf <- data.frame(
-                    start = indexVec[-length(indexVec)],
-                    end = indexVec[-1]
+                    start = starts,
+                    end = c(starts[-1] - 1, l)
                 )
                 n <- nrow(indexDf)
                 indexDf$file <- paste0('_subset_', 1:n,'_of_',n)


### PR DESCRIPTION
Hi ! I'm currently building a pipeline using IsoformSwitchAnalyzeR where I tried to merge the subset fasta files produced to make bigger batches for the sequence analysis tools. However I got errors because duplicate sequences were found in my batched files. So I investigated and I found that the last sequence of a file is the first sequence of the next fasta file.

example of one the duplicate found:
```sh
$ grep -n "922470" isoformSwitchAnalyzeR_isoform_AA_subset_*
isoformSwitchAnalyzeR_isoform_AA_subset_174_of_416.fasta:3468:>ENST00000922470.1
isoformSwitchAnalyzeR_isoform_AA_subset_175_of_416.fasta:1:>ENST00000922470.1

$ cat isoformSwitchAnalyzeR_isoform_AA_subset_174_of_416.fasta | wc -l
3471
```