### PR TITLE
Update package citation to IsoformSwitchAnalyzeR v2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: IsoformSwitchAnalyzeR
 Type: Package
 Title: Identify, Annotate and Visualize Isoform Switches with Functional Consequences from both short- and long-read RNA-seq data
-Version: 2.11.1
+Version: 2.11.2
 Authors@R: c(person(given="Kristoffer",family="Vitting-Seerup", role=c("cre","aut"),email="k.vitting.seerup@gmail.com",comment = c(ORCID = "0000-0002-6450-0608")), person(given="Chunxu",family="Han", role="ctb",email="chunxuhan007@gmail.com"), person(given="Jeroen",family="Gilis", role="ctb", email="jeroen.gilis@ugent.be",comment = c(ORCID = "0000-0001-8415-0943")), person(given="Elena Iriondo", family="Delgado", role="ctb",email="eleni.iriondo2@gmail.com"))
 Description: Analysis of alternative splicing and isoform switches with predicted functional
     consequences (e.g. gain/loss of protein domains etc.) from quantification of all types of

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,23 +1,26 @@
 citHeader("To cite package 'IsoformSwitchAnalyzeR' in publications, use:")
 
-citEntry(
-   entry="Article",
-   title = "The Landscape of Isoform Switches in Human Cancers",
-   author = "Kristoffer Vitting-Seerup, Albin Sandelin",
-   journal = "Mol. Cancer Res",
-   year = 2017,
-   doi = "10.1158/1541-7786.MCR-16-0459",
-   url = "http://mcr.aacrjournals.org/content/early/2017/06/02/1541-7786.MCR-16-0459",
-   textVersion = "Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017)."
-)
-
-citEntry(
-   entry="Article",
-   title = "IsoformSwitchAnalyzeR: Analysis of changes in genome-wide patterns of alternative splicing and its functional consequences",
-   author = "Kristoffer Vitting-Seerup, Albin Sandelin",
-   journal = "Bioinformatics",
-   year = 2019,
-   doi = "10.1093/bioinformatics/btz247",
-   url = "http://dx.doi.org/10.1093/bioinformatics/btz247",
-   textVersion = "Vitting-Seerup et al. IsoformSwitchAnalyzeR: Analysis of changes in genome-wide patterns of alternative splicing and its functional consequences. Bioinformatics. (2019)."
+bibentry(
+   bibtype = "Article",
+   title   = "IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data",
+   author  = c(
+      person("Chunxu", "Han"),
+      person("Jeroen", "Gilis"),
+      person("Elena", "Iriondo Delgado"),
+      person("Lieven", "Clement"),
+      person("Kristoffer", "Vitting-Seerup")
+   ),
+   journal = "NAR Genomics and Bioinformatics",
+   year    = 2026,
+   volume  = 8,
+   number  = 3,
+   pages   = "lqag098",
+   doi     = "10.1093/nargab/lqag098",
+   url     = "https://doi.org/10.1093/nargab/lqag098",
+   textVersion = paste(
+      "Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K (2026).",
+      "IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in",
+      "long-read and single-cell sequencing data. NAR Genomics and",
+      "Bioinformatics, 8(3), lqag098. https://doi.org/10.1093/nargab/lqag098"
+   )
 )

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,9 @@
+Changes in version 2.11.2 (2026-09)
+- Update type: Minor.
+- Updated the package citation throughout the documentation and vignette to
+  reference IsoformSwitchAnalyzeR v2 (Han et al., NAR Genom Bioinform 2026,
+  doi:10.1093/nargab/lqag098).
+
 Changes in version 2.11.1 (2025-11)
 - Update type: Minor.
 - Updated deprecated functions and minor modifications

--- a/man/IsoformSwitchTestDEXSeq.Rd
+++ b/man/IsoformSwitchTestDEXSeq.Rd
@@ -92,7 +92,7 @@ The data.frame added have one row per isoform per comparison of condition and co
 }
 
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 Anders et al. Detecting differential usage of exons from RNA-seq data. Genome Research (2012).
 }
 

--- a/man/IsoformSwitchTestSatuRn.Rd
+++ b/man/IsoformSwitchTestSatuRn.Rd
@@ -94,6 +94,7 @@ The data.frame added have one row per isoform per comparison of condition and co
 }
 
 \references{
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 Gilis, J., Vitting-Seerup, K., Van den Berge, K., & Clement, L. (2022). satuRn: Scalable analysis of differential transcript usage for bulk and single-cell RNA-sequencing applications (version 2). F1000Research, 10:374. https://doi.org/10.12688/f1000research.51749.2
 }
 

--- a/man/addORFfromGTF.Rd
+++ b/man/addORFfromGTF.Rd
@@ -58,7 +58,7 @@ The switchAnalyzeRlist given as input is annotated with ORF information, as desc
 
 \references{
 \itemize{
-\item{\code{This function} : Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).}
+\item{\code{This function} : Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.}
 \item{\code{Information about NMD} : Weischenfeldt J, et al: Mammalian tissues defective in nonsense-mediated mRNA decay display highly aberrant splicing patterns. Genome Biol. 2012, 13:R35.}
 }
 }

--- a/man/analyzeAlternativSplicing.Rd
+++ b/man/analyzeAlternativSplicing.Rd
@@ -72,8 +72,7 @@ A \code{switchAnalyzeRlist} where the column \code{IR} indicating the number of 
 
 \references{
 \itemize{
-    \item{Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).}
-    \item{Vitting-Seerup et al. IsoformSwitchAnalyzeR: Analysis of changes in genome-wide patterns of alternative splicing and its functional consequences. bioRxiv (2018).}
+    \item{Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.}
 }
 }
 

--- a/man/analyzeCPAT.Rd
+++ b/man/analyzeCPAT.Rd
@@ -46,7 +46,7 @@ Two columns are added to \code{isoformFeatures}: 'codingPotentialValue' and 'cod
 
 \references{
     \itemize{
-        \item{\code{This function} : Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).}
+        \item{\code{This function} : Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.}
         \item{\code{CPAT} : Wang et al. CPAT: Coding-Potential Assessment Tool using an alignment-free logistic regression model. Nucleic Acids Res. 2013, 41:e74.}
     }
 }

--- a/man/analyzeCPC2.Rd
+++ b/man/analyzeCPC2.Rd
@@ -44,7 +44,7 @@ Two columns are added to \code{isoformFeatures}: 'codingPotentialValue' and 'cod
 
 \references{
     \itemize{
-        \item{\code{This function} : Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).}
+        \item{\code{This function} : Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.}
         \item{\code{CPC2} : Kang et al CPC2: a fast and accurate coding potential calculator based on sequence intrinsic features. Nucleic Acids Res. 2017}
     }
 }

--- a/man/analyzeDeepLoc2.Rd
+++ b/man/analyzeDeepLoc2.Rd
@@ -64,7 +64,7 @@ The data.frame added have one row pr isoform and contains 12 columns:
 
 \references{
 \itemize{
-    \item{\code{This function} : Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).}
+    \item{\code{This function} : Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.}
 }
 }
 

--- a/man/analyzeDeepTMHMM.Rd
+++ b/man/analyzeDeepTMHMM.Rd
@@ -62,7 +62,7 @@ The data.frame added have one row per topological region of an isoform and conta
 
 \references{
 \itemize{
-    \item{\code{This function} : Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).}
+    \item{\code{This function} : Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.}
     \item{\code{DeepTMHMM} : Hallgren et al: In prep.}
 }
 }

--- a/man/analyzeIUPred2A.Rd
+++ b/man/analyzeIUPred2A.Rd
@@ -109,7 +109,7 @@ The data.frame added have one row per isoform and contains the columns:
 
 \references{
 \itemize{
-    \item{\code{This function} : Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).}
+    \item{\code{This function} : Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.}
     \item{\code{IUPred2A} : Meszaros et al. IUPred2A: Context-dependent prediction of protein disorder as a function of redox state and protein binding. Nucleic Acids Res (2018).}
 }
 }

--- a/man/analyzeNetSurfP3.Rd
+++ b/man/analyzeNetSurfP3.Rd
@@ -96,7 +96,7 @@ The data.frame added have one row per isoform and contains the columns:
 
 \references{
 \itemize{
-    \item{\code{This function} : Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).}
+    \item{\code{This function} : Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.}
     \item{\code{NetSurfP-3} : Hoeie et al: NetSurfP-3.0: accurate and fast prediction of protein structural features by protein language models and deep learning. Nucleic Acids Research (2022).}
 }
 }

--- a/man/analyzeNovelIsoformORF.Rd
+++ b/man/analyzeNovelIsoformORF.Rd
@@ -77,7 +77,7 @@ For the isoforms analysed the ORF information in the switchAnalyzeRlist given as
 
 \references{
 \itemize{
-\item{\code{This function} : Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).}
+\item{\code{This function} : Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.}
 \item{\code{Information about NMD} : Weischenfeldt J, et al: Mammalian tissues defective in nonsense-mediated mRNA decay display highly aberrant splicing patterns. Genome Biol. 2012, 13:R35.}
 }
 }

--- a/man/analyzeORF.Rd
+++ b/man/analyzeORF.Rd
@@ -105,7 +105,7 @@ NA means no information was available aka no ORF (passing the \code{minORFlength
 
 \references{
 \itemize{
-\item{\code{This function} : Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).}
+\item{\code{This function} : Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.}
 \item{\code{Information about NMD} : Weischenfeldt J, et al: Mammalian tissues defective in nonsense-mediated mRNA decay display highly aberrant splicing patterns. Genome Biol. 2012, 13:R35.}
 }
 }

--- a/man/analyzePFAM.Rd
+++ b/man/analyzePFAM.Rd
@@ -87,7 +87,7 @@ Furthermore depending on the exact tool used (local vs web-server) additional co
 
 \references{
 \itemize{
-    \item{\code{This function} : Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).}
+    \item{\code{This function} : Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.}
     \item{\code{Pfam} : Finn et al. The Pfam protein families database. Nucleic Acids Research (2014)  Database Issue 42:D222-D230}
     \item{\code{pfamAnalyzeR} :Vitting-Seerup. Most protein domains exist as multiple variants with distinct structure and function. BioRxiv 2022}
 }

--- a/man/analyzeSignalP.Rd
+++ b/man/analyzeSignalP.Rd
@@ -63,7 +63,7 @@ The data.frame added have one row pr isoform and contains 6 columns:
 
 \references{
 \itemize{
-    \item{\code{This function} : Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).}
+    \item{\code{This function} : Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.}
     \item{\code{SignalP} : Almagro et al. SignalP 5.0 improves signal peptide predictions using deep neural networks. Nat. Biotechnol (2019).}
 }
 }

--- a/man/analyzeSwitchConsequences.Rd
+++ b/man/analyzeSwitchConsequences.Rd
@@ -180,7 +180,7 @@ Secondly the data.frame 'switchConsequence' is added to the \code{switchAnalyzeR
 }
 
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 }
 \author{
 Kristoffer Vitting-Seerup

--- a/man/expressionAnalysisPlots.Rd
+++ b/man/expressionAnalysisPlots.Rd
@@ -86,7 +86,7 @@ Note that the bar indicating significance levels will only be shown if the analy
 }
 
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 }
 
 \author{Kristoffer Vitting-Seerup}

--- a/man/extractConsequenceEnrichment.Rd
+++ b/man/extractConsequenceEnrichment.Rd
@@ -87,8 +87,7 @@ If \code{returnResult=TRUE} a data.frame with the statistical summary for each o
 
 \references{
 \itemize{
-    \item{Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).}
-    \item{Vitting-Seerup et al. IsoformSwitchAnalyzeR: Analysis of changes in genome-wide patterns of alternative splicing and its functional consequences. Bioinformatics (2019).}
+    \item{Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.}
 }
 }
 \author{

--- a/man/extractConsequenceEnrichmentComparison.Rd
+++ b/man/extractConsequenceEnrichmentComparison.Rd
@@ -68,8 +68,7 @@ If \code{returnResult=TRUE} a data.frame with the statistical summary for each o
 
 \references{
 \itemize{
-    \item{Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).}
-    \item{Vitting-Seerup et al. IsoformSwitchAnalyzeR: Analysis of changes in genome-wide patterns of alternative splicing and its functional consequences. Bioinformatics (2019).}
+    \item{Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.}
 }
 }
 \author{

--- a/man/extractConsequenceSummary.Rd
+++ b/man/extractConsequenceSummary.Rd
@@ -76,7 +76,7 @@ If \code{returnResult=TRUE} a data.frame with the number (and fraction) of switc
 }
 
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 }
 \author{
 Kristoffer Vitting-Seerup

--- a/man/extractGeneExpression.Rd
+++ b/man/extractGeneExpression.Rd
@@ -43,7 +43,7 @@ A data.frame with the replicate count/abundance estimates as well as gene_id (an
 }
 
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 }
 \author{
 Kristoffer Vitting-Seerup

--- a/man/extractGenomeWideAnalysis.Rd
+++ b/man/extractGenomeWideAnalysis.Rd
@@ -122,7 +122,7 @@ If \code{returnResult=TRUE}: A data.frame with the summary statistics from the c
 }
 
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 }
 
 \author{

--- a/man/extractGenomeWideSplicingAnalysis.Rd
+++ b/man/extractGenomeWideSplicingAnalysis.Rd
@@ -109,7 +109,7 @@ If \code{returnResult=TRUE}: A data.frame with the summary statistics from the c
 }
 
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 }
 
 \author{

--- a/man/extractSequence.Rd
+++ b/man/extractSequence.Rd
@@ -104,7 +104,7 @@ If \code{addToSwitchAnalyzeRlist=TRUE} the sequences are added to the \code{swit
 \references{
 For
 \itemize{
-    \item{\code{This function} : Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).}
+    \item{\code{This function} : Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.}
 }
 }
 

--- a/man/extractSplicingEnrichment.Rd
+++ b/man/extractSplicingEnrichment.Rd
@@ -113,8 +113,7 @@ If \code{returnResult=TRUE} a data.frame with the statistical summary for each o
 
 \references{
 \itemize{
-    \item{Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).}
-    \item{Vitting-Seerup et al. IsoformSwitchAnalyzeR: Analysis of changes in genome-wide patterns of alternative splicing and its functional consequences. Bioinformatics (2019).}
+    \item{Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.}
 }
 }
 \author{

--- a/man/extractSplicingEnrichmentComparison.Rd
+++ b/man/extractSplicingEnrichmentComparison.Rd
@@ -92,8 +92,7 @@ If \code{returnResult=TRUE} a data.frame with the statistical summary for each o
 
 \references{
 \itemize{
-    \item{Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).}
-    \item{Vitting-Seerup et al. IsoformSwitchAnalyzeR: Analysis of changes in genome-wide patterns of alternative splicing and its functional consequences. Bioinformatics (2019).}
+    \item{Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.}
 }
 }
 \author{

--- a/man/extractSplicingSummary.Rd
+++ b/man/extractSplicingSummary.Rd
@@ -89,7 +89,7 @@ If \code{returnResult=TRUE} a data.frame with the number (and fraction) of switc
 }
 
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 }
 \author{
 Kristoffer Vitting-Seerup

--- a/man/extractSubCellShifts.Rd
+++ b/man/extractSubCellShifts.Rd
@@ -59,8 +59,7 @@ If \code{returnResult=TRUE} a data.frame with the summary for each comparison. T
 
 \references{
 \itemize{
-    \item{Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).}
-    \item{Vitting-Seerup et al. IsoformSwitchAnalyzeR: Analysis of changes in genome-wide patterns of alternative splicing and its functional consequences. Bioinformatics (2019).}
+    \item{Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.}
 }
 }
 \author{

--- a/man/extractSwitchOverlap.Rd
+++ b/man/extractSwitchOverlap.Rd
@@ -57,7 +57,7 @@ A Venn diagram which shows the number of isoforms and genes with a isoform switc
 
 \references{
 \itemize{
-    \item{Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).}
+    \item{Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.}
 }
 }
 

--- a/man/extractSwitchSummary.Rd
+++ b/man/extractSwitchSummary.Rd
@@ -44,7 +44,7 @@ A \code{data.frame} with the number of switches found in each comparison (as wel
 }
 
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 }
 
 \author{

--- a/man/extractTopSwitches.Rd
+++ b/man/extractTopSwitches.Rd
@@ -54,7 +54,7 @@ A \code{data.frame} containing the top \code{n} switching genes or isoforms as c
 }
 
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 }
 
 \author{

--- a/man/importCufflinksGalaxyData.Rd
+++ b/man/importCufflinksGalaxyData.Rd
@@ -91,7 +91,7 @@ The guestimate produced by setting \code{estimateDifferentialGeneRange = TRUE} i
 A \code{switchAnalyzeRlist} containing all the gene and transcript information as well as the isoform structure. See ?switchAnalyzeRlist for more details. If \code{addCufflinksSwichTest=TRUE} a data.frame with the result of CuffDiffs test for alternative splicing is also added to the switchAnalyzeRlist under the entry 'isoformSwitchAnalysis' (only if analysis was performed).
 }
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 }
 \author{
 Kristoffer Vitting-Seerup

--- a/man/importGTF.Rd
+++ b/man/importGTF.Rd
@@ -95,7 +95,7 @@ NA means no information was available aka no ORF (passing the \code{minORFlength
 
 }
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 }
 \author{
 Kristoffer Vitting-Seerup

--- a/man/importIsoformExpression.Rd
+++ b/man/importIsoformExpression.Rd
@@ -87,7 +87,7 @@ Transcripts Per Million values are abbreviated to TPM by RSEM, Kallisto and Salm
 }
 
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 Soneson et al. Differential analyses for RNA-seq: transcript-level estimates improve gene-level inferences. F1000Research 4, 1521 (2015).
 Robinson et al. A scaling normalization method for differential expression analysis of RNA-seq data. Genome Biology (2010)
 }

--- a/man/importPairedGSEA.Rd
+++ b/man/importPairedGSEA.Rd
@@ -128,7 +128,7 @@ If no genes match after filtering, an empty \code{switchAnalyzeRlist} is returne
 }
 
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 Dam, S.H., Olsen, L.R. & Vitting-Seerup, K. Expression and splicing mediate distinct biological signals. BMC Biol 21, 220 (2023).
 }
 \author{

--- a/man/importRdata.Rd
+++ b/man/importRdata.Rd
@@ -206,7 +206,7 @@ For many of the downstream steps in the IsoformSwitchAnalyzeR workflow additiona
 
 
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 }
 \author{
 Kristoffer Vitting-Seerup

--- a/man/importSalmonData.Rd
+++ b/man/importSalmonData.Rd
@@ -67,7 +67,7 @@ A SwitchAnalyzeRlist containing the data supplied stored into the SwitchAnalyzeR
 
 \references{
 \itemize{
-    \item{\code{IsoformSwitchAnalyzeR}: Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017)..}
+    \item{\code{IsoformSwitchAnalyzeR}: Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.}
     \item{\code{Tximeta}: Love et al. Tximeta: Reference sequence checksums for provenance identification in RNA-seq. PLoS Comput. Biol. (2020).}
 }
 }

--- a/man/isoformSwitchAnalysisCombined.Rd
+++ b/man/isoformSwitchAnalysisCombined.Rd
@@ -84,7 +84,7 @@ This function outputs:
 }
 
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 }
 \author{
 Kristoffer Vitting-Seerup

--- a/man/isoformSwitchAnalysisPart1.Rd
+++ b/man/isoformSwitchAnalysisPart1.Rd
@@ -75,7 +75,7 @@ This function have two outputs. It returns a \code{switchAnalyzeRlist} object wh
 }
 
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 }
 \author{
 Kristoffer Vitting-Seerup

--- a/man/isoformSwitchAnalysisPart2.Rd
+++ b/man/isoformSwitchAnalysisPart2.Rd
@@ -136,7 +136,7 @@ This function
 }
 
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 }
 \author{
 Kristoffer Vitting-Seerup

--- a/man/isoformToGeneExp.Rd
+++ b/man/isoformToGeneExp.Rd
@@ -42,7 +42,7 @@ This function returns a data.frame with gene expression from all samples. The ge
 }
 
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 }
 \author{
 Kristoffer Vitting-Seerup

--- a/man/isoformToIsoformFraction.Rd
+++ b/man/isoformToIsoformFraction.Rd
@@ -49,7 +49,7 @@ A replicate isoform fraction matrix with layout similar to \code{isoformRepExpre
 }
 
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 }
 \author{
 Kristoffer Vitting-Seerup

--- a/man/preFilter.Rd
+++ b/man/preFilter.Rd
@@ -98,7 +98,7 @@ Please note that for the exon entry as well as any replicate matrix entry (count
 A \code{switchAnalyzeRlist} object where the genes and isoforms not passing the filters have been removed (from all annotated entries)
 }
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 }
 \author{
 Kristoffer Vitting-Seerup

--- a/man/prepareSalmonFilesDataFrame.Rd
+++ b/man/prepareSalmonFilesDataFrame.Rd
@@ -46,7 +46,7 @@ The data.frame with 3 columns.
 
 
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 }
 
 \author{

--- a/man/subsetSwitchAnalyzeRlist.Rd
+++ b/man/subsetSwitchAnalyzeRlist.Rd
@@ -28,7 +28,7 @@ A SwitchAnalyzeRlist only containing information about the isoforms (in their sp
 }
 
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 }
 \author{
 Kristoffer Vitting-Seerup

--- a/man/switchAnalyzeRlist.Rd
+++ b/man/switchAnalyzeRlist.Rd
@@ -106,7 +106,7 @@ When fully analyzed the \code{isoformFeatures} entry of the  will furthermore co
 }
 \author{Kristoffer Vitting-Seerup}
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 }
 
 \examples{

--- a/man/switchPlot.Rd
+++ b/man/switchPlot.Rd
@@ -104,7 +104,7 @@ The switchPlot contains regions "Not Annotated" if regions were not analyzed due
 A isoform switch analysis plot
 }
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 }
 \author{
 Kristoffer Vitting-Seerup

--- a/man/switchPlotTopSwitches.Rd
+++ b/man/switchPlotTopSwitches.Rd
@@ -91,7 +91,7 @@ For a list of the top switching genes see ?extractTopSwitches.
 An Isoform Switch Analysis Plot (as produce by \code{switchPlot}) for each of the top n switches in each comparison where a gene have a significant isoform switch is generated in the folder supplied by \code{pathToOutput}
 }
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 }
 \author{
 Kristoffer Vitting-Seerup

--- a/man/switchPlotTranscript.Rd
+++ b/man/switchPlotTranscript.Rd
@@ -151,7 +151,7 @@ Returns the gg object which can then be modified or plotted in a different setti
 }
 
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 }
 
 \author{

--- a/man/testData.Rd
+++ b/man/testData.Rd
@@ -40,7 +40,7 @@ The exampleSwitchListAnalyzed is a subset of two of the TCGA Cancer types analyz
 }
 
 \references{
-Vitting-Seerup et al. The Landscape of Isoform Switches in Human Cancers. Mol. Cancer Res. (2017).
+Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data. NAR Genom Bioinform (2026). doi:10.1093/nargab/lqag098.
 }
 
 \examples{

--- a/vignettes/IsoformSwitchAnalyzeR.Rmd
+++ b/vignettes/IsoformSwitchAnalyzeR.Rmd
@@ -144,7 +144,7 @@ In summary, IsoformSwitchAnalyzeR enables analysis of RNA-seq data with isoform 
 
 The usage of Alternative Transcription Start sites (aTSS), Alternative Splicing (AS) and alternative Transcription Termination Sites (aTTS) are collectively collectively results in the production of different isoforms. Alternative isoforms are widely used as recently demonstrated by The ENCODE Consortium, which found that on average, 6.3 different transcripts are generated per gene; a number which may vary considerably per gene.
 
-The importance of analyzing isoforms instead of genes has been highlighted by many examples showing functionally important changes. One of these examples is the pyruvate kinase. In normal adult homeostasis, cells use the adult isoform (M1), which supports oxidative phosphorylation. However, almost all cancer cells use the embryonic isoform (M2), which promotes aerobic glycolysis, one of the hallmarks of cancer. Such shifts in isoform usage are termed 'isoform switching' and cannot be detected at when only analyzing data on gene level. For an introduction to isoform switches please refere to [Vitting-Seerup et al 2017](http://mcr.aacrjournals.org/content/15/9/1206.long).
+The importance of analyzing isoforms instead of genes has been highlighted by many examples showing functionally important changes. One of these examples is the pyruvate kinase. In normal adult homeostasis, cells use the adult isoform (M1), which supports oxidative phosphorylation. However, almost all cancer cells use the embryonic isoform (M2), which promotes aerobic glycolysis, one of the hallmarks of cancer. Such shifts in isoform usage are termed 'isoform switching' and cannot be detected at when only analyzing data on gene level. For an introduction to isoform switches please refer to [Han et al 2026](https://doi.org/10.1093/nargab/lqag098).
 
 On a more systematic level several recent studies suggest that isoform switches are quite common since they often identify hundreds of switch events in both cancer and non-cancer studies.
 
@@ -238,51 +238,50 @@ The analysis performed by IsoformSwitchAnalyzeR is only possible due to a string
 
 If you are using the:
 
--   **Import of data from Salmon/Kallisto/RSEM/StringTie (importRdata() function)**: Please cite reference *10*.
--   **Import of data from Salmon via Tximeta (importSalmonData() function)**: Please cite reference *10* and *17*.
--   **Inter-library normalization of abundance values**: Please cite reference *10* and *11*.
--   **Isoform switch test implemented utilizing DEXSeq via IsoformSwitchAnalyzeR (Default)** : Please cite reference *1*, *12* and *13*.
--   **Isoform switch test implemented in the satuRn package**: Please cite reference *3*.
--   **Prediction of open reading frames (ORF) analysis**: Please cite reference *1* and *4*.
--   **Prediction of pre-mature termination codons (PTC) and thereby NMD-sensitivity**: Please cite reference *1*, *4*, *5* and *6*.
--   **CPAT**: Please cite reference *7*.
--   **CPC2**: Please cite reference *14*.
--   **Pfam**: Please cite reference *8*.
--   **Pfam isotypes**: Please cite reference *20*.
--   **SignalP**: Please cite reference *9*.
--   **NetSurf3-P**: Please cite reference *15*.
--   **IUPred2A**: Please cite reference *16*.
--   **Deeploc2**: Please cite reference *18*.
--   **DeepTMHMM**: Please cite reference *19*.
+-   **Import of data from Salmon/Kallisto/RSEM/StringTie (importRdata() function)**: Please cite reference *9*.
+-   **Import of data from Salmon via Tximeta (importSalmonData() function)**: Please cite reference *9* and *16*.
+-   **Inter-library normalization of abundance values**: Please cite reference *9* and *10*.
+-   **Isoform switch test implemented utilizing DEXSeq via IsoformSwitchAnalyzeR (Default)** : Please cite reference *1*, *11* and *12*.
+-   **Isoform switch test implemented in the satuRn package**: Please cite reference *1* and *2*.
+-   **Prediction of open reading frames (ORF) analysis**: Please cite reference *1* and *3*.
+-   **Prediction of pre-mature termination codons (PTC) and thereby NMD-sensitivity**: Please cite reference *1*, *3*, *4* and *5*.
+-   **CPAT**: Please cite reference *6*.
+-   **CPC2**: Please cite reference *13*.
+-   **Pfam**: Please cite reference *7*.
+-   **Pfam isotypes**: Please cite reference *19*.
+-   **SignalP**: Please cite reference *8*.
+-   **NetSurf3-P**: Please cite reference *14*.
+-   **IUPred2A**: Please cite reference *15*.
+-   **Deeploc2**: Please cite reference *17*.
+-   **DeepTMHMM**: Please cite reference *18*.
 -   **Prediction of consequences**: Please cite reference *1*.
 -   **Visualizations** (plots) implemented in the IsoformSwitchAnalyzeR package: Please cite reference *1*.
--   **Alternative splicing analysis**: Please cite both reference *1* and *4*.
--   **Genome-wide enrichment analysis**: Please cite both reference *1* and *2*.
+-   **Alternative splicing analysis**: Please cite both reference *1* and *3*.
+-   **Genome-wide enrichment analysis**: Please cite reference *1*.
 
 <br />
 
 **Refrences**:
 
-1.  *Vitting-Seerup et al. **The Landscape of Isoform Switches in Human Cancers.** Cancer Res. (2017)* [link](http://mcr.aacrjournals.org/content/15/9/1206.long).
-2.  *Vitting-Seerup et al. **IsoformSwitchAnalyzeR: Analysis of changes in genome-wide patterns of alternative splicing and its functional consequences.** Bioinformatics (2019)* [link](http://dx.doi.org/10.1093/bioinformatics/btz247).
-3.  *Gilis et al. **satuRn: Scalable analysis of differential transcript usage for bulk and single-cell RNA-sequencing applications (version 2)**.* F1000Research, 10:374. [link](https://doi.org/10.12688/f1000research.51749.2)
-4.  *Vitting-Seerup et al. **spliceR: an R package for classification of alternative splicing and prediction of coding potential from RNA-seq data**. BMC Bioinformatics 2014, 15:81.* [link](http://www.biomedcentral.com/1471-2105/15/81).
-5.  *Weischenfeldt et al. **Mammalian tissues defective in nonsense-mediated mRNA decay display highly aberrant splicing patterns**. Genome Biol 2012, 13:R35* [link](https://genomebiology.biomedcentral.com/articles/10.1186/gb-2012-13-5-r35).
-6.  *Huber et al. **Orchestrating high-throughput genomic analysis with Bioconductor**. Nat. Methods, 2015, 12:115-121.* [link](https://www.nature.com/articles/nmeth.3252).
-7.  *Wang et al. **CPAT: Coding-Potential Assessment Tool using an alignment-free logistic regression model**. Nucleic Acids Res. 2013, 41:e74.* [link](https://academic.oup.com/nar/article/41/6/e74/2902455).
-8.  *Finn et al. **The Pfam protein families database**. Nucleic Acids Research (2012)* [link](https://academic.oup.com/nar/article/40/D1/D290/2903007).
-9.  \_Teufel et al. SignalP 6.0 predicts all five types of signal peptides using protein language models.\*\*. Nat. Biotechnol (2022)\_ [link](https://www.nature.com/articles/s41587-021-01156-3)
-10. *Soneson et al. **Differential analyses for RNA-seq: transcript-level estimates improve gene-level inferences.** F1000Research 4, 1521 (2015).* [link](https://f1000research.com/articles/4-1521/v2).
-11. *Robinson et al. **A scaling normalization method for differential expression analysis of RNA-seq data**. Genome Biology (2010)* [link](https://genomebiology.biomedcentral.com/articles/10.1186/gb-2010-11-3-r25).
-12. *Ritchie et al. **limma powers differential expression analyses for RNA-sequencing and microarray studies**. Nucleic Acids Research (2015)* [link](https://academic.oup.com/nar/article/43/7/e47/2414268).
-13. *Anders et al. **Detecting differential usage of exons from RNA-seq data**. Genome Research (2012)* [link](https://genome.cshlp.org/content/22/10/2008.long).
-14. *Kang et al. **CPC2: a fast and accurate coding potential calculator based on sequence intrinsic features**. Nucleic Acids Res (2017)* [link](https://academic.oup.com/nar/article/45/W1/W12/3831091).
-15. *H??ie et al. **NetSurfP-3.0: accurate and fast prediction of protein structural features by protein language models and deep learning**. Nucleic Acids Research (2022)* [link](https://doi.org/10.1093/nar/gkac439)
-16. *Meszaros et al. IUPred2A: Context-dependent prediction of protein disorder as a function of redox state and protein binding. Nucleic Acids Res (2018)* [link](https://doi.org/10.1093/nar/gky384)
-17. *Love et al. Tximeta: Reference sequence checksums for provenance identification in RNA-seq. PLoS Comput. Biol (2020)* [link](http://dx.doi.org/10.1371/journal.pcbi.1007664)
-18. *Thumuluri et al. DeepLoc 2.0: multi-label subcellular localization prediction using protein language models. Nucleic Acids Res (2022)* [link](http://dx.doi.org/10.1093/nar/gkac278)
-19. *Hallgren et al. DeepTMHMM predicts alpha and beta transmembrane proteins using deep neural networks. bioRxiv (2022)* [link](https://doi.org/10.1101/2022.04.08.487609)
-20. *Vitting-Seerup. Most protein domains exist as multiple variants with distinct structure and function. bioRxiv (2022)* [link](https://www.biorxiv.org/content/10.1101/2022.08.12.503740v1)
+1.  *Han C, Gilis J, Iriondo Delgado E, Clement L, Vitting-Seerup K. **IsoformSwitchAnalyzeR v2: analysis of functional isoform changes in long-read and single-cell sequencing data.** NAR Genom Bioinform (2026)* [link](https://doi.org/10.1093/nargab/lqag098).
+2.  *Gilis et al. **satuRn: Scalable analysis of differential transcript usage for bulk and single-cell RNA-sequencing applications (version 2)**.* F1000Research, 10:374. [link](https://doi.org/10.12688/f1000research.51749.2)
+3.  *Vitting-Seerup et al. **spliceR: an R package for classification of alternative splicing and prediction of coding potential from RNA-seq data**. BMC Bioinformatics 2014, 15:81.* [link](http://www.biomedcentral.com/1471-2105/15/81).
+4.  *Weischenfeldt et al. **Mammalian tissues defective in nonsense-mediated mRNA decay display highly aberrant splicing patterns**. Genome Biol 2012, 13:R35* [link](https://genomebiology.biomedcentral.com/articles/10.1186/gb-2012-13-5-r35).
+5.  *Huber et al. **Orchestrating high-throughput genomic analysis with Bioconductor**. Nat. Methods, 2015, 12:115-121.* [link](https://www.nature.com/articles/nmeth.3252).
+6.  *Wang et al. **CPAT: Coding-Potential Assessment Tool using an alignment-free logistic regression model**. Nucleic Acids Res. 2013, 41:e74.* [link](https://academic.oup.com/nar/article/41/6/e74/2902455).
+7.  *Finn et al. **The Pfam protein families database**. Nucleic Acids Research (2012)* [link](https://academic.oup.com/nar/article/40/D1/D290/2903007).
+8.  \_Teufel et al. SignalP 6.0 predicts all five types of signal peptides using protein language models.\*\*. Nat. Biotechnol (2022)\_ [link](https://www.nature.com/articles/s41587-021-01156-3)
+9.  *Soneson et al. **Differential analyses for RNA-seq: transcript-level estimates improve gene-level inferences.** F1000Research 4, 1521 (2015).* [link](https://f1000research.com/articles/4-1521/v2).
+10. *Robinson et al. **A scaling normalization method for differential expression analysis of RNA-seq data**. Genome Biology (2010)* [link](https://genomebiology.biomedcentral.com/articles/10.1186/gb-2010-11-3-r25).
+11. *Ritchie et al. **limma powers differential expression analyses for RNA-sequencing and microarray studies**. Nucleic Acids Research (2015)* [link](https://academic.oup.com/nar/article/43/7/e47/2414268).
+12. *Anders et al. **Detecting differential usage of exons from RNA-seq data**. Genome Research (2012)* [link](https://genome.cshlp.org/content/22/10/2008.long).
+13. *Kang et al. **CPC2: a fast and accurate coding potential calculator based on sequence intrinsic features**. Nucleic Acids Res (2017)* [link](https://academic.oup.com/nar/article/45/W1/W12/3831091).
+14. *H??ie et al. **NetSurfP-3.0: accurate and fast prediction of protein structural features by protein language models and deep learning**. Nucleic Acids Research (2022)* [link](https://doi.org/10.1093/nar/gkac439)
+15. *Meszaros et al. IUPred2A: Context-dependent prediction of protein disorder as a function of redox state and protein binding. Nucleic Acids Res (2018)* [link](https://doi.org/10.1093/nar/gky384)
+16. *Love et al. Tximeta: Reference sequence checksums for provenance identification in RNA-seq. PLoS Comput. Biol (2020)* [link](http://dx.doi.org/10.1371/journal.pcbi.1007664)
+17. *Thumuluri et al. DeepLoc 2.0: multi-label subcellular localization prediction using protein language models. Nucleic Acids Res (2022)* [link](http://dx.doi.org/10.1093/nar/gkac278)
+18. *Hallgren et al. DeepTMHMM predicts alpha and beta transmembrane proteins using deep neural networks. bioRxiv (2022)* [link](https://doi.org/10.1101/2022.04.08.487609)
+19. *Vitting-Seerup. Most protein domains exist as multiple variants with distinct structure and function. bioRxiv (2022)* [link](https://www.biorxiv.org/content/10.1101/2022.08.12.503740v1)
 
 <br />
 
@@ -2498,7 +2497,7 @@ Importantly there are also extensions of this analysis approach which jointly an
 
 The idea with this type of analysis it to utilize the transcript level quantification of the RNASeq data to detect changes in which transcripts are used in the two conditions (isoform switches). Although this is from a computational point a harder task (less events are found) the biological interpretation is a lot easier because you know the entire transcript. According to [Love et al 2018](https://f1000research.com/articles/7-952/v3) again DEXSeq (testing transcripts instead of exons) seems to be the best tool to find such changes.
 
-For the biological interpertration of such isoform switches IsoformSwitchAnalyzeR was created. IsoformSwitchAnalyzeR enables identification and analysis of alternative splicing as well as isoform switches with predicted functional consequences (such as gain/loss of protein domains etc) from quantification by Kallisto, Salmon, Cufflinks/CuffFiff, RSEM etc. IsoformSwitchAnalyzeR allows for analysis and visualizations of both individual genes as well as genome wide analysis of changes in both splicing and isoform switch consequences. For high level introduction you can jump to the [Abstract] or the [Quick Start]. Alternatively you can jump directly to the [Examples Visualizations] IsoformSwitchAnalyzeR can perform. For more info you can see how the analysis of switch consequences can be used in [Vitting-Seerup *et al* 2017](http://mcr.aacrjournals.org/content/15/9/1206.long) and for more info on the genome wide analysis take a look at [Vitting-Seerup *et al* 2019](http://dx.doi.org/10.1093/bioinformatics/btz247).
+For the biological interpertration of such isoform switches IsoformSwitchAnalyzeR was created. IsoformSwitchAnalyzeR enables identification and analysis of alternative splicing as well as isoform switches with predicted functional consequences (such as gain/loss of protein domains etc) from quantification by Kallisto, Salmon, Cufflinks/CuffFiff, RSEM etc. IsoformSwitchAnalyzeR allows for analysis and visualizations of both individual genes as well as genome wide analysis of changes in both splicing and isoform switch consequences. For high level introduction you can jump to the [Abstract] or the [Quick Start]. Alternatively you can jump directly to the [Examples Visualizations] IsoformSwitchAnalyzeR can perform. For more info on both the analysis of switch consequences and the genome wide analysis take a look at [Han *et al* 2026](https://doi.org/10.1093/nargab/lqag098).
 
 Lastly there are also analysis extentions to the transcript based analysis which performs the statistical association on groups of transcripts (often via transcript compatability counts) or on gene level - but just like the tools analyzing groups of splice events the biological interpretability is next to impossibe.
 


### PR DESCRIPTION
Updates the package citation to IsoformSwitchAnalyzeR v2 (Han et al., *NAR Genomics and Bioinformatics* 2026, 8(3):lqag098, doi:10.1093/nargab/lqag098), replacing the 2017 Mol Cancer Res and 2019 Bioinformatics papers as the "how to cite" reference.

**Updated:** `inst/CITATION`, the vignette reference list and its "Please cite reference *N*" pointers, 49 `man/*.Rd` `\references{}` blocks, `DESCRIPTION` and `inst/NEWS` (v2.11.2).
